### PR TITLE
update import paths

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/heptio/eventrouter",
+	"ImportPath": "github.com/openshift/eventrouter",
 	"GoVersion": "go1.7",
 	"GodepVersion": "v79",
 	"Deps": [

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TARGET = eventrouter
-BUILDMNT = /go/src/github.com/heptio/$(TARGET)
+BUILDMNT = /go/src/github.com/openshift/$(TARGET)
 REGISTRY ?= gcr.io/heptio-images
 VERSION ?= v0.1
 IMAGE = $(REGISTRY)/$(BIN)

--- a/eventrouter.go
+++ b/eventrouter.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/heptio/eventrouter/sinks"
+	"github.com/openshift/eventrouter/sinks"
 	"github.com/prometheus/client_golang/prometheus"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"


### PR DESCRIPTION
This is a fork of `heptio/eventrouter` but with different package url the imports should change to `openshift/eventrouter`