### PR TITLE
Updating centos install to add scl first

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,4 +1,4 @@
-FROM centos:centos7 
+FROM centos:centos7
 
 LABEL maintainer="OpenShift Development <dev@lists.openshift.redhat.com>" \
       com.redhat.component="openshift-eventrouter-docker" \
@@ -12,15 +12,16 @@ RUN mkdir /go
 
 ENV GOPATH=/go
 
-RUN yum -y install golang git
+RUN yum -y install centos-release-scl-rh && \
+    yum -y install go-toolset-7
 
 WORKDIR /go
 
-RUN go get github.com/openshift/eventrouter
+RUN scl enable go-toolset-7 'go get github.com/openshift/eventrouter'
 
 WORKDIR /go/src/github.com/openshift/eventrouter
 
-RUN go build
+RUN scl enable go-toolset-7 'go build'
 
 USER nobody
 


### PR DESCRIPTION
Addresses 
```
[openshift/origin-logging-eventrouter] --> RUN go get github.com/openshift/eventrouter
[openshift/origin-logging-eventrouter] /bin/sh: go: command not found
[openshift/origin-logging-eventrouter] running 'go get github.com/openshift/eventrouter' failed with exit code 127
[ERROR] PID 3566: hack/build-images.sh:56: `return "${result}"` exited with status 1.
[INFO] 		Stack Trace: 
[INFO] 		  1: hack/build-images.sh:56: `return "${result}"`
[INFO]   Exiting with code 1.
```