### PR TITLE
Add epel-release repo after centos removed golang.

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -12,7 +12,9 @@ RUN mkdir /go
 
 ENV GOPATH=/go
 
-RUN yum -y install golang git
+RUN yum -y install epel-release \
+ && yum -y install golang git
+
 
 WORKDIR /go
 


### PR DESCRIPTION
The golang package has been removed from CentOS 7.6[0] and this is causing the container image not to build. We can get the package by pulling in the epel repos.

[0] https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.1810#head-e467ac744557df926ed56dc0106f43961e5ffc38