### PR TITLE
Bug 1701495: Eventrouter pod in CrashLoopBackOff status: "runtime error: invalid memory address or nil pointer dereference"

### DIFF
--- a/yaml/eventrouter.yaml
+++ b/yaml/eventrouter.yaml
@@ -51,7 +51,7 @@ metadata:
   name: eventrouter-cm
   namespace: kube-system
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: eventrouter


### PR DESCRIPTION
Add explicit support for an `"Info"` type, and use "unknown" for any type
not explicitly handled by this code.  Note that I am unable to cause my
4.x testing cluster to produce events of any type other than "Normal"
and "Warning", so I don't know how common it is to see "Info" or other
event types.