### PR TITLE
Add Dockerfile.rhel8

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -1,0 +1,8 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+WORKDIR  /go/src/github.com/openshift/eventrouter
+COPY . .
+RUN go build .
+
+FROM registry.ci.openshift.org/ocp/4.6:base
+COPY --from=build /go/src/github.com/openshift/eventrouter/eventrouter /bin/eventrouter
+CMD ["/bin/eventrouter", "-v", "3", "-logtostderr"]


### PR DESCRIPTION
Add Dockerfile.rhel8 it will be used for building event router image from sources.

https://github.com/openshift/ocp-build-data/pull/886 

Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>