### PR TITLE
feat: add enable-prometheus flag

### DIFF
--- a/eventrouter.go
+++ b/eventrouter.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift/eventrouter/sinks"
 	"github.com/prometheus/client_golang/prometheus"
-
+	"github.com/spf13/viper"
 	v1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -75,10 +75,12 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(kubernetesWarningEventCounterVec)
-	prometheus.MustRegister(kubernetesNormalEventCounterVec)
-	prometheus.MustRegister(kubernetesInfoEventCounterVec)
-	prometheus.MustRegister(kubernetesUnknownEventCounterVec)
+	if viper.GetBool("enable-prometheus") {
+		prometheus.MustRegister(kubernetesWarningEventCounterVec)
+		prometheus.MustRegister(kubernetesNormalEventCounterVec)
+		prometheus.MustRegister(kubernetesInfoEventCounterVec)
+		prometheus.MustRegister(kubernetesUnknownEventCounterVec)
+	}
 }
 
 // EventRouter is responsible for maintaining a stream of kubernetes
@@ -158,6 +160,10 @@ func (er *EventRouter) updateEvent(objOld interface{}, objNew interface{}) {
 
 // prometheusEvent is called when an event is added or updated
 func prometheusEvent(event *v1.Event) {
+	if !viper.GetBool("enable-prometheus") {
+		return
+	}
+
 	var counter prometheus.Counter
 	var err error
 

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func loadConfig() kubernetes.Interface {
 	viper.SetDefault("kubeconfig", "")
 	viper.SetDefault("sink", "glog")
 	viper.SetDefault("resync-interval", time.Minute*30)
+	viper.SetDefault("enable-prometheus", true)
 	if err = viper.ReadInConfig(); err != nil {
 		panic(err.Error())
 	}
@@ -114,11 +115,13 @@ func main() {
 	stop := sigHandler()
 
 	// Startup the http listener for Prometheus Metrics endpoint.
-	go func() {
-		glog.Info("Starting prometheus metrics.")
-		http.Handle("/metrics", promhttp.Handler())
-		glog.Warning(http.ListenAndServe(*addr, nil))
-	}()
+	if viper.GetBool("enable-prometheus") {
+		go func() {
+			glog.Info("Starting prometheus metrics.")
+			http.Handle("/metrics", promhttp.Handler())
+			glog.Warning(http.ListenAndServe(*addr, nil))
+		}()
+	}
 
 	// Startup the EventRouter
 	wg.Add(1)


### PR DESCRIPTION
This PR adds the support of an extra flag `enable-prometheus`. On some K8S clusters with high number of events the memory of eventrouter increases a lot because of metrics cardinality, until being killed. In my case, I don't need metrics but only events to be propagated to loki on which I aggregate data to have some metrics.