### PR TITLE
remove heptiolabs remains

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ _sink_
 ## Running Eventrouter 
 Standup: 
 ```
-$ kubectl create -f https://raw.githubusercontent.com/heptiolabs/eventrouter/master/yaml/eventrouter.yaml
+$ kubectl create -f https://raw.githubusercontent.com/openshift/eventrouter/master/yaml/eventrouter.yaml
 ```
 Teardown: 
 ```
-$ kubectl delete -f https://raw.githubusercontent.com/heptiolabs/eventrouter/master/yaml/eventrouter.yaml
+$ kubectl delete -f https://raw.githubusercontent.com/openshift/eventrouter/master/yaml/eventrouter.yaml
 ```
 
 ### Inspecting the output 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/crewjam/rfc5424 v0.0.0-20180723152949-c25bdd3a0ba2
 	github.com/eapache/channels v1.1.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/heptiolabs/eventrouter v0.0.0-20191206192100-eec922928a3f
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/heptiolabs/eventrouter v0.0.0-20191206192100-eec922928a3f h1:l/A1EqLyX2KRIXKDQSNgNi8fdQWst1hxzSjynJTakNY=
-github.com/heptiolabs/eventrouter v0.0.0-20191206192100-eec922928a3f/go.mod h1:GE6tAIcNtPaEYd6NXoC1k+eJXUfMN8ThFrGb83gWfbc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/tests/kafka/main.go
+++ b/tests/kafka/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/heptiolabs/eventrouter/sinks"
+	"github.com/openshift/eventrouter/sinks"
 	"github.com/kelseyhightower/envconfig"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
There were still a few old references in this fork.

I still have issues pulling the image (as specified in the k8s manufest yaml) though
```
Error response from daemon: failed to resolve reference "registry.redhat.io/openshift-logging/eventrouter-rhel8:v5.5": failed to authorize: failed to fetch anonymous token: unexpected status: 401 Unauthorized
```