### PR TITLE
LOG-4532: Update dockerfile to ubi minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY sinks ./sinks
 
 RUN make build
 
-FROM registry.redhat.io/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 1000
 COPY --from=builder /go/src/github.com/openshift/eventrouter/eventrouter /bin/eventrouter
 CMD ["/bin/eventrouter", "-v", "3", "-logtostderr"]


### PR DESCRIPTION
### Description
This PR:
* Updates CLO Dockerfile to use ubi minimal

### Links
* https://issues.redhat.com/browse/LOG-4532