### PR TITLE
Add optional /debug/pprof http route

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,5 +3,6 @@
 "sink": "glog",
 "httpSinkUrl": "http://localhost:8080",
 "httpSinkBufferSize": 1500,
-"httpSinkDiscardMessages": true
+"httpSinkDiscardMessages": true,
+"enable-http-pprof": false
 }


### PR DESCRIPTION
The event router in our cluster appears to have a memory leak.
In order to debug that I would like to capture a heap dump using `net/http/pprof`.
This change adds `/debug/pprof` as an optional (disabled by default) http route.