### PR TITLE
Fix image used in ART Dockerfile

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,4 +1,4 @@
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.0-202510150934.g4284440.el9 AS builder
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1


### PR DESCRIPTION
This is only relevant for "local testing" of the build.

/cc @jcantrill 
/label tide/merge-method-squash


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker builder base image to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->