### PR TITLE
LOG-9588: Upgrade Go builder image to 1.25.11 for CVE-2026-42504

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,4 +1,4 @@
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.11-202607210343.p0.g5a8ff2f.el9 AS builder
+FROM registry.redhat.io/openshift/art-images-base:openshift-golang-builder-container-v1.26.5-202607161626.p2.g48af02f.el9 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1

--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,4 +1,4 @@
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9 AS builder
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.11-202607210343.p0.g5a8ff2f.el9 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/openshift/eventrouter
 
-go 1.25.11
+go 1.25.0
+
+toolchain go1.26.5
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/eventrouter
 
-go 1.25.0
+go 1.25.11
 
 require (
 	github.com/IBM/sarama v1.46.3


### PR DESCRIPTION
## Summary
- Upgrades ART builder base image from Go 1.25.9 to 1.25.11
- Remediates CVE-2026-42504 (Golang MIME: DoS via maliciously-crafted MIME header, CVSS 7.5)
- Remediates CVE-2026-33811 (Go net package: Denial of Service via long CNAME response in LookupCNAME)
- The upstream `Dockerfile` uses the floating `golang:1.25` tag which already resolves to the patched version

## Test plan
- [ ] Verify the image `v1.25.11-202607210343.p0.g5a8ff2f.el9` exists in the registry
- [ ] Build with `Dockerfile.art` succeeds
- [ ] `go version` in the resulting builder stage reports 1.25.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to a newer Go builder image.
  * Added an explicit Go toolchain version for the project build setup.
  * No changes to runtime behavior or end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes:
* https://redhat.atlassian.net/browse/LOG-9586
 * https://redhat.atlassian.net/browse/LOG-9587
 * https://redhat.atlassian.net/browse/LOG-9588
 * https://redhat.atlassian.net/browse/LOG-9590
 * https://redhat.atlassian.net/browse/LOG-9536

